### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,61 @@
-find_library(CRYPTOPP_LIB cryptopp REQUIRED)
-
-
-set(source_files
-    model/zt-certificate.cc
-    model/zt-encryption-utils.cc
-    model/zt-policy-engine.cc
-    model/zt-logger.cc
-    model/zt-tls-handshake.cc
+# Default: Crypto++ disabled
+set(ENABLE_CRYPTOPP
+    False
+    CACHE INTERNAL ""
 )
 
-set(header_files
-    model/zt-certificate.h
-    model/zt-encryption-utils.h
-    model/zt-policy-engine.h
-    model/zt-logger.h
-    model/zt-tls-handshake.h
-)
+# Allow user to request Crypto++ explicitly
+option(NS3_CRYPTOPP "Enable Crypto++ support in zero-trust-iot" OFF)
 
-build_lib(
-  LIBNAME zero-trust-iot
-  SOURCE_FILES ${source_files}
-  HEADER_FILES ${header_files}
-  LIBRARIES_TO_LINK ${libcore} ${libnetwork} ${libinternet} ${libwifi}  PUBLIC ${CRYPTOPP_LIB}
-)
+if(NS3_CRYPTOPP)
+  find_package(PkgConfig REQUIRED)
+
+  # Look for Crypto++ via pkg-config
+  pkg_check_modules(CRYPTOPP cryptopp)
+
+  if(CRYPTOPP_FOUND)
+    message(STATUS "Crypto++ found")
+    set(ENABLE_CRYPTOPP True CACHE INTERNAL "")
+    include_directories(${CRYPTOPP_INCLUDE_DIRS})
+    add_definitions(-DENABLE_CRYPTOPP)
+  else()
+    message(FATAL_ERROR "NS3_CRYPTOPP=ON but Crypto++ not found via pkg-config")
+  endif()
+else()
+  message(STATUS "Crypto++ support explicitly disabled (NS3_CRYPTOPP=OFF)")
+endif()
+
+# Sources/headers
+set(crypto_sources)
+set(crypto_headers)
+set(crypto_libraries)
+
+if(ENABLE_CRYPTOPP)
+  set(crypto_sources
+      model/zt-certificate.cc
+      model/zt-encryption-utils.cc
+      model/zt-policy-engine.cc
+      model/zt-logger.cc
+      model/zt-tls-handshake.cc
+  )
+  set(crypto_headers
+      model/zt-certificate.h
+      model/zt-encryption-utils.h
+      model/zt-policy-engine.h
+      model/zt-logger.h
+      model/zt-tls-handshake.h
+  )
+  set(crypto_libraries ${CRYPTOPP_LIBRARIES})
+
+  build_lib(
+    LIBNAME zero-trust-iot
+    SOURCE_FILES ${crypto_sources}
+    HEADER_FILES ${crypto_headers}
+    LIBRARIES_TO_LINK
+      ${libcore}
+      ${libnetwork}
+      ${libinternet}
+      ${libwifi}
+      ${crypto_libraries}
+  )
+endif()


### PR DESCRIPTION
Fixes #3 

Updated CMakeLists.txt file such that it will not break the build;
The following cases are verified:
1. Cryptopp is present and enabled (build succeeds by processing it)
2. Cryptopp is enabled but not present (build fails)
3. Cryptopp is disabled (by default) it skips building this module zero-trust-iot but build does not break